### PR TITLE
Fix build on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ include config.mk
 PWD=$(shell pwd)
 PREFIX?=/usr
 BINDIR=${DESTDIR}${PREFIX}/bin
-OBJ=spp.o main.o
+OBJ=spp.o bin/main.o
 # r_api.o
 ODF=$(subst .o,.d,$(OBJ))
 BIN=spp

--- a/bin/main.c
+++ b/bin/main.c
@@ -1,7 +1,7 @@
 /* MIT pancake <pancake@nopcode.org> (C) 2009-2020 */
 
-#include "spp.h"
-#include "r_api.h"
+#include "../spp.h"
+#include "../r_api.h"
 
 extern struct Proc *procs[];
 extern struct Proc *proc;

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,0 +1,4 @@
+spp_exe = executable('spp', ['main.c', '../spp.c'],
+  include_directories: ['.', '..'],
+  dependencies: spp_dep,
+  install: true)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('spp', 'c')
-spp_version = '1.0.0'
+spp_version = '1.2.0'
 
 configure_file(input: 'config.def.h',
   output: 'config.h',
@@ -7,7 +7,6 @@ configure_file(input: 'config.def.h',
 
 spp_files = [
   'spp.c',
-  's_api.c'
 ]
 
 libspp_static = static_library('spp', spp_files,
@@ -38,9 +37,5 @@ pkgconfig_mod.generate(libspp,
 
 if not meson.is_subproject()
   install_headers('spp.h')
-
-  spp_exe = executable('spp', ['main.c'],
-    dependencies: spp_dep,
-    install: true
-  )
+  subdir('bin')
 endif

--- a/r_api.c
+++ b/r_api.c
@@ -1,6 +1,10 @@
 /* radare2 - LGPL - Copyright 2013-2020 - pancake */
 
+#if __UNIX__
 #include <unistd.h>
+#elif __WINDOWS__
+#include <windows.h>
+#endif
 #include "spp.h"
 #include "r_api.h"
 
@@ -117,13 +121,13 @@ int r_sys_setenv(const char *key, const char *value) {
 char *r_sys_getenv(const char *key) {
 #if __WINDOWS__
 	DWORD dwRet;
-	char *envbuf = NULL, tmp_ptr;
+	char *envbuf = NULL, *tmp_ptr;
 	char *val = NULL;
 	const int TMP_BUFSIZE = 4096;
 	if (!key) {
 		return NULL;
 	}
-	envbuf = (envbuf)malloc (sizeof (envbuf) * TMP_BUFSIZE);
+	envbuf = malloc (sizeof (envbuf) * TMP_BUFSIZE);
 	if (!envbuf) {
 		goto err_r_sys_get_env;
 	}
@@ -133,7 +137,7 @@ char *r_sys_getenv(const char *key) {
 			goto err_r_sys_get_env;
 		}
 	} else if (TMP_BUFSIZE < dwRet) {
-		tmp_ptr = (char *)realloc (envbuf, dwRet);
+		tmp_ptr = realloc (envbuf, dwRet);
 		if (!tmp_ptr) {
 			goto err_r_sys_get_env;
 		}


### PR DESCRIPTION
* DWORD was not found on windows
* tmp_ptr had the wrong type
* generating both libspp and spp executable in the same build dir caused
  an error because on windows both things generate a spp.lib file. To
  solve this issue, move the spp executable to a separate `bin` directory


On linux, I tried both configure and meson.
On windows only meson.
They both work.

However, on radare2 we are still using an older version of sdb and we will need to adjust some things there to make it work. (not because of this PR, but just because there were some changes in spp which are not yet ported to r2).